### PR TITLE
Enable assertions for project

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,10 @@ test {
     finalizedBy jacocoTestReport
 }
 
+run {
+    enableAssertions = true
+}
+
 task coverage(type: JacocoReport) {
     sourceDirectories.from files(sourceSets.main.allSource.srcDirs)
     classDirectories.from files(sourceSets.main.output)


### PR DESCRIPTION
Enabled assertions for the project through `build.gradle` file.