### PR TITLE
Fix parsing and display of year 0000

### DIFF
--- a/src/main/java/seedu/address/model/schedule/Time.java
+++ b/src/main/java/seedu/address/model/schedule/Time.java
@@ -12,8 +12,8 @@ import java.time.format.DateTimeParseException;
  * Guarantees: immutable; is valid as declared in {@link #isValidTimeString(String)}
  */
 public abstract class Time implements Comparable<Time> {
-    public static final String DATETIME_INPUT_FORMAT = "yyyy-MM-dd'T'HH:mm";
-    public static final String DATETIME_OUTPUT_FORMAT = "MMM d yyyy HH:mm";
+    public static final String DATETIME_INPUT_FORMAT = "uuuu-MM-dd'T'HH:mm";
+    public static final String DATETIME_OUTPUT_FORMAT = "MMM d uuuu HH:mm";
     public static final String VALIDATION_REGEX = "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}";
 
     public final LocalDateTime value;


### PR DESCRIPTION
Change datetime format in schedule to use `uuuu` instead of `yyyy`

TLDR: Year 0000 is not real ~~and it cant hurt you~~, it is actually 1 BC which is why it shows as 0001 but the era is not shown. 

`uuuu` just uses signed numbers to represent the different eras so 0 = 1BC, -1 = 2BC.

Read more here: https://stackoverflow.com/a/65984229


---

Also if you try to parse `0000-01-01` it throws `DateTimeParseException` but `0000-01-01T00:00` doesn't