### PR TITLE
Truncate calendar view when schedules are short

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -860,7 +860,7 @@ This command might seem complicated, but it is easy to use with only 1 possible 
 <div markdown="block" class="alert alert-warning">
 
 **:warning: Calendar Limitations**<br>
-* Schedules with very short duration may not be displayed correctly (the schedule's index, status and time will not be visible).
+* Schedules with very short duration will be truncated (only the schedule's index will be displayed).
 * Using any other commands will hide the calendar view. Use the `show` command to view calendar again. 
 
 </div>

--- a/src/main/java/seedu/address/ui/CalendarCard.java
+++ b/src/main/java/seedu/address/ui/CalendarCard.java
@@ -54,7 +54,12 @@ public class CalendarCard extends UiPart<Region> {
         card.setTranslateX(translateX);
 
         this.index.setText(index.getOneBased() + "");
-        this.timeLabel.setText(timeLabel);
-        this.status.setText(status);
+        if (width > 75) {
+            this.timeLabel.setText(timeLabel);
+            this.status.setText(status);
+        } else {
+            this.timeLabel.setText("");
+            this.status.setText("");
+        }
     }
 }


### PR DESCRIPTION
Only displays the schedule index when the schedule is short.
The min width to display full schedule information is 45 minutes.

![telegram-cloud-photo-size-5-6213157612778797176-x](https://github.com/AY2324S1-CS2103T-T17-3/tp/assets/32407747/51e21ecf-7bbb-4ec1-b980-8be7cb30e796)

![telegram-cloud-photo-size-5-6213157612778797177-x](https://github.com/AY2324S1-CS2103T-T17-3/tp/assets/32407747/a7a0c36a-a594-4dd1-934b-a8e0af1a6c98)

![telegram-cloud-photo-size-5-6213157612778797178-x](https://github.com/AY2324S1-CS2103T-T17-3/tp/assets/32407747/db4c68f2-436f-4de1-be41-6501284fe887)
