### PR TITLE
Prevent long fields from being truncated

### DIFF
--- a/src/main/resources/view/CalendarRow.fxml
+++ b/src/main/resources/view/CalendarRow.fxml
@@ -4,6 +4,7 @@
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.Region?>
 
 <GridPane xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
   <HBox fx:id="rowLeftBox" alignment="CENTER_LEFT" minHeight="50" prefWidth="200" GridPane.columnIndex="0">
@@ -11,7 +12,12 @@
       <Insets top="5" right="5" bottom="5" left="15" />
     </padding>
     <HBox spacing="5" alignment="CENTER_LEFT">
-      <Label fx:id="id" styleClass="cell_big_label"/>
+      <Label fx:id="id" styleClass="cell_big_label">
+        <minWidth>
+          <!-- Ensures that the label text is never truncated -->
+          <Region fx:constant="USE_PREF_SIZE" />
+        </minWidth>
+      </Label>
       <Label fx:id="name" styleClass="cell_big_label" />
     </HBox>
   </HBox>

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -11,9 +11,6 @@
 
 <HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
   <GridPane HBox.hgrow="ALWAYS">
-    <columnConstraints>
-      <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />
-    </columnConstraints>
     <VBox alignment="CENTER_LEFT" minHeight="105" GridPane.columnIndex="0">
       <padding>
         <Insets top="5" right="5" bottom="5" left="15" />

--- a/src/main/resources/view/ScheduleListCard.fxml
+++ b/src/main/resources/view/ScheduleListCard.fxml
@@ -9,9 +9,6 @@
 <?import javafx.scene.layout.VBox?>
 <HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
     <GridPane HBox.hgrow="ALWAYS">
-        <columnConstraints>
-            <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150"/>
-        </columnConstraints>
         <VBox alignment="CENTER_LEFT" minHeight="105" GridPane.columnIndex="0">
             <padding>
                 <Insets top="5" right="5" bottom="5" left="15"/>


### PR DESCRIPTION
Removes the column constraint from PersonListCard and ScheduleListCard that limits the size of the cards.

This allows the two cards to grow horizontally as needed with a horizontal scroll added when field exceeds a certain length and overflows beyond the list width.

![Screen Recording 2023-11-05 at 12 19 13 PM](https://github.com/AY2324S1-CS2103T-T17-3/tp/assets/32407747/2d6fe2c4-8f02-4c43-a1e6-30e87b0a3271)

The only exception for this is in calendar view, as there are alternative means to view the full tutor name (`list-t`):
<img width="225" alt="image" src="https://github.com/AY2324S1-CS2103T-T17-3/tp/assets/32407747/5cc6933a-20e8-4a4c-8f51-156a966282c7">
