### PR TITLE
Prevent malformed json save file from crashing app on startup

### DIFF
--- a/src/main/java/seedu/address/model/schedule/Schedule.java
+++ b/src/main/java/seedu/address/model/schedule/Schedule.java
@@ -47,11 +47,17 @@ public class Schedule implements Comparable<Schedule> {
         this.status = status;
     }
 
-    private boolean isValidSchedule(StartTime startTime, EndTime endTime) {
+
+    //@@author dishenggg
+    /**
+     * Checks if the {@code StartTime} and {@code EndTime} make up a valid schedule.
+     */
+    public static boolean isValidSchedule(StartTime startTime, EndTime endTime) {
         boolean isStartTimeAfterEndTime = startTime.getTime().isBefore(endTime.getTime());
         boolean isSameDay = startTime.compareDays(endTime) == 0;
         return isStartTimeAfterEndTime && isSameDay;
     }
+    //@@author
 
     public Person getTutor() {
         return tutor;

--- a/src/main/java/seedu/address/storage/JsonAdaptedSchedule.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedSchedule.java
@@ -14,7 +14,6 @@ import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
-import seedu.address.model.person.exceptions.PersonNotFoundException;
 import seedu.address.model.schedule.EndTime;
 import seedu.address.model.schedule.Schedule;
 import seedu.address.model.schedule.StartTime;
@@ -26,6 +25,7 @@ import seedu.address.model.schedule.Status;
 class JsonAdaptedSchedule {
 
     public static final String MISSING_FIELD_MESSAGE_FORMAT = "Schedule's %s field is missing!";
+    public static final String MISSING_TUTOR_MESSAGE_FORMAT = "Tutor not found!";
     private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern(DATETIME_INPUT_FORMAT);
 
     private final String name;
@@ -40,7 +40,7 @@ class JsonAdaptedSchedule {
      */
     @JsonCreator
     public JsonAdaptedSchedule(@JsonProperty("name") String name, @JsonProperty("startTime") String startTime,
-                               @JsonProperty("endTime") String endTime, @JsonProperty("status") String status) {
+        @JsonProperty("endTime") String endTime, @JsonProperty("status") String status) {
         this.name = name;
         this.startTime = startTime;
         this.endTime = endTime;
@@ -94,19 +94,28 @@ class JsonAdaptedSchedule {
         if (!Status.isValidStatus(status)) {
             throw new IllegalValueException(Status.MESSAGE_CONSTRAINTS);
         }
-        return new Schedule(getTutorFromName(modelName, addressBook), modelStartTime, modelEndTime,
+
+        if (!Schedule.isValidSchedule(modelStartTime, modelEndTime)) {
+            throw new IllegalValueException(Schedule.MESSAGE_CONSTRAINTS);
+        }
+
+        final Person tutor = getTutorFromName(modelName, addressBook);
+
+        return new Schedule(tutor, modelStartTime, modelEndTime,
             Status.valueOf(status));
     }
 
+    //@@author saltedfishxx
     /**
      * Helper method to find the tutor object given the name stored in json file.
      *
-     * @throws PersonNotFoundException if no matching names were found in the tutors list.
+     * @throws IllegalValueException if no matching names were found in the tutors list.
      */
-    private Person getTutorFromName(Name name, ReadOnlyAddressBook addressBook) throws PersonNotFoundException {
+    private Person getTutorFromName(Name name, ReadOnlyAddressBook addressBook) throws IllegalValueException {
         ObservableList<Person> tutors = addressBook.getPersonList();
         return tutors.stream().filter(o -> name.equals(o.getName())).findFirst()
-            .orElseThrow(PersonNotFoundException::new);
+            .orElseThrow(() -> new IllegalValueException(MISSING_TUTOR_MESSAGE_FORMAT));
     }
+    //@@author
 
 }

--- a/src/test/java/seedu/address/storage/JsonAdaptedScheduleTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedScheduleTest.java
@@ -24,6 +24,9 @@ public class JsonAdaptedScheduleTest {
     private static final String INVALID_STARTTIME = "15/02/2023 6pm";
     private static final String INVALID_ENDTIME = "14/02/2023 6pm";
     private static final String INVALID_STATUS = "status";
+    private static final String INVALID_STARTTIME2 = SCHEDULE_ALICE_FIRST_JAN.getEndTime().getTime().format(formatter);
+    private static final String INVALID_ENDTIME2 = SCHEDULE_ALICE_FIRST_JAN.getStartTime().getTime().format(formatter);
+    private static final String INVALID_TUTOR_NAME = "DoesNotExist";
 
     private static final String VALID_NAME = SCHEDULE_ALICE_FIRST_JAN.getTutor().getName().toString();
     private static final String VALID_STARTTIME = SCHEDULE_ALICE_FIRST_JAN.getStartTime().getTime().format(formatter);
@@ -94,6 +97,20 @@ public class JsonAdaptedScheduleTest {
     @Test
     public void toModelType_nullStatus_throwsIllegalValueException() {
         JsonAdaptedSchedule schedule = new JsonAdaptedSchedule(VALID_NAME, VALID_STARTTIME, VALID_ENDTIME, null);
+        assertThrows(IllegalValueException.class, () -> schedule.toModelType(original));
+    }
+
+    @Test
+    public void toModelType_endTimeBeforeStartTime_throwsIllegalValueException() {
+        JsonAdaptedSchedule schedule = new JsonAdaptedSchedule(VALID_NAME, INVALID_STARTTIME2, INVALID_ENDTIME2,
+            VALID_STATUS);
+        assertThrows(IllegalValueException.class, () -> schedule.toModelType(original));
+    }
+
+    @Test
+    public void toModelType_tutorWithNameNotFound_throwsIllegalValueException() {
+        JsonAdaptedSchedule schedule = new JsonAdaptedSchedule(INVALID_TUTOR_NAME, VALID_STARTTIME, VALID_ENDTIME,
+            VALID_STATUS);
         assertThrows(IllegalValueException.class, () -> schedule.toModelType(original));
     }
 

--- a/src/test/java/seedu/address/storage/JsonSerializableAddressBookTest.java
+++ b/src/test/java/seedu/address/storage/JsonSerializableAddressBookTest.java
@@ -60,7 +60,7 @@ public class JsonSerializableAddressBookTest {
     public void toModelType_invalidScheduleFile_throwsIllegalValueException() throws Exception {
         JsonSerializableAddressBook dataFromFile = JsonUtil.readJsonFile(INVALID_SCHEDULE_FILE,
                 JsonSerializableAddressBook.class).get();
-        assertThrows(IllegalArgumentException.class, MESSAGE_CONSTRAINTS,
+        assertThrows(IllegalValueException.class, MESSAGE_CONSTRAINTS,
                 dataFromFile::toModelType);
     }
 


### PR DESCRIPTION
Catches the following exceptions thrown by malformed json:
- Invalid tutor name
- End time before start time